### PR TITLE
[SEC-16633] Renamed env.local to .env.local; improved --update flag

### DIFF
--- a/Devolutions Server/.gitignore
+++ b/Devolutions Server/.gitignore
@@ -6,6 +6,6 @@
 certificates
 .env
 .env.backup
-env.local
+.env.local
 __pycache__/
 output.log

--- a/Devolutions Server/README.md
+++ b/Devolutions Server/README.md
@@ -10,7 +10,7 @@
 > We advise changing the variable values in the `env.template` file before running. It is your responsibility to secure those variables.
 > Do not use the default provided values.
 
-Copy `env.template` to `env.local` if you want to override specific values without touching the template (see [env.local overrides](#envlocal-overrides)).
+Copy `env.template` to `.env.local` if you want to override specific values without touching the template (see [.env.local overrides](#envlocal-overrides)).
 
 # Run
 
@@ -47,7 +47,7 @@ python run.py [--update]
 
 | Flag | Description |
 |------|-------------|
-| `--update` | Pulls the latest Docker images before starting |
+| `--update` | Rebuilds `.env` from template, pulls the latest Docker images, and force-recreates all containers |
 
 To access the server go to https://localhost:5544
 
@@ -71,23 +71,23 @@ Certificates are stored in the `Certificates/` folder (gitignored). The script a
 
 To force a full certificate regeneration, delete the `Certificates/` folder and rerun.
 
-# env.local overrides
+# .env.local overrides
 
-Create an `env.local` file (gitignored) to override specific variables from `env.template` without modifying the template:
+Create a `.env.local` file (gitignored) to override specific variables from `env.template` without modifying the template:
 
 ```bash
-# env.local — personal overrides, never committed
+# .env.local — personal overrides, never committed
 SQL_MSSQL_PASSWORD=MyCustomPassword123
 GTW_HOSTNAME=gateway.custom
 ```
 
-Values in `env.local` take precedence over `env.template`. Certificate B64 variables are always injected automatically and should not be set manually.
+Values in `.env.local` take precedence over `env.template`. Certificate B64 variables are always injected automatically and should not be set manually.
 
 # .env file documentation
 
-The `.env` file is rebuilt from `env.template` (+ `env.local` overrides) on every run. **Do not edit `.env` directly** — changes will be overwritten.
+The `.env` file is rebuilt from `env.template` (+ `.env.local` overrides) on every run. **Do not edit `.env` directly** — changes will be overwritten.
 
-### Configurable variables (in `env.template` / `env.local`)
+### Configurable variables (in `env.template` / `.env.local`)
 
 | Variable | Description |
 |----------|-------------|
@@ -117,6 +117,7 @@ These are populated at runtime from files in `Certificates/`:
 
 # Changelog
 
+- 31/03/2026 - Renamed `env.local` to `.env.local`; `--update` on `run.py` now also rebuilds `.env` and force-recreates containers
 - 24/03/2026 - Migrated to Python scripts, added logging to output.log, fixed SQL data folder cleanup
 - 17/03/2026 - Improved .env management, certificate handling, and Windows compatibility
 - 04/03/2026 - Updated containers to v2026.1.6.0

--- a/Devolutions Server/install.py
+++ b/Devolutions Server/install.py
@@ -97,9 +97,9 @@ def _build_env(script_dir: Path) -> None:
     env_path.write_text(content)
     print("✅ Created .env from env.template")
 
-    local = script_dir / "env.local"
+    local = script_dir / ".env.local"
     if local.exists():
-        print("📝 Applying env.local overrides...")
+        print("📝 Applying .env.local overrides...")
         local_content = env_path.read_text()
         for line in local.read_text().splitlines():
             line = line.strip()
@@ -112,7 +112,7 @@ def _build_env(script_dir: Path) -> None:
             else:
                 local_content += f"\n{line}"
         env_path.write_text(local_content)
-        print("✅ env.local overrides applied")
+        print("✅ .env.local overrides applied")
 
     placeholders = (
         "\n# Certificate variables (auto-generated — do not edit manually)\n"

--- a/Devolutions Server/run.py
+++ b/Devolutions Server/run.py
@@ -14,6 +14,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+import install as _install
 import logger
 
 SCRIPT_DIR = Path(__file__).parent.resolve()
@@ -80,11 +81,17 @@ def main() -> None:
 
     os.chdir(SCRIPT_DIR)
 
+    if args.update:
+        print("\nRegenerating .env...")
+        _install._build_env(SCRIPT_DIR)
+        _install._inject_certificates(SCRIPT_DIR / ".env", CERT_DIR)
+        print("✓ .env regenerated.")
+
     env = _load_env()
     if not env:
         print("⚠️  .env not found — run install.py first")
         sys.exit(1)
-        
+
     # Check Docker is in Linux containers mode
     os_type = subprocess.run(
         ["docker", "info", "--format", "{{.OSType}}"],
@@ -104,7 +111,10 @@ def main() -> None:
         print("✓ Containers updated successfully.")
 
     print("\nStarting Docker Compose...")
-    result = subprocess.run(["docker", "compose", "up", "-d"], cwd=SCRIPT_DIR)
+    up_cmd = ["docker", "compose", "up", "-d"]
+    if args.update:
+        up_cmd.append("--force-recreate")
+    result = subprocess.run(up_cmd, cwd=SCRIPT_DIR)
     if result.returncode != 0:
         print("❌ Failed to start Docker Compose.")
         sys.exit(1)


### PR DESCRIPTION
## Jira Ticket
- [SEC-16633](https://devolutions.atlassian.net/browse/SEC-16633)

## Description

Renames the personal override file from `env.local` to `.env.local` (dot-prefixed, consistent with `.env` convention and already gitignored). Also improves the `--update` flag on `run.py` so it fully refreshes the environment: it now rebuilds `.env` from the template (picking up any override changes) and passes `--force-recreate` to Docker Compose to ensure containers are restarted with the latest configuration.

## Technical Information

**Changes:**
- Renamed `env.local` → `.env.local` in `.gitignore`, `README.md`, `install.py`, and `run.py`
- `run.py --update` now calls `_install._build_env()` and `_install._inject_certificates()` before starting containers
- `docker compose up` gains `--force-recreate` when `--update` is passed
- Updated README changelog and flag description table

## Commits

- 8bab555 - [SEC-16633] Rename env.local to .env.local; --update now rebuilds .env and force-recreates containers

[SEC-16633]: https://devolutions.atlassian.net/browse/SEC-16633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SEC-16633]: https://devolutions.atlassian.net/browse/SEC-16633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ