### PR TITLE
Sync DVLS Docker scripts from security-public (2026-04-28)

### DIFF
--- a/Devolutions Server/.gitignore
+++ b/Devolutions Server/.gitignore
@@ -3,7 +3,10 @@
 *.exists
 *.ndf
 *.bin
-certificates
+Certificates/*
+data-dvls/*
+data-sql/*
+tmp
 .env
 .env.backup
 .env.local

--- a/Devolutions Server/README.md
+++ b/Devolutions Server/README.md
@@ -117,6 +117,7 @@ These are populated at runtime from files in `Certificates/`:
 
 # Changelog
 
+- 28/04/2026 - `run.py --update` now clears `sql.configured` sentinel so SQL Server reconfigures on new images; `.gitignore` updated to properly ignore `Certificates/`, `data-dvls/`, `data-sql/`, `tmp`
 - 31/03/2026 - Renamed `env.local` to `.env.local`; `--update` on `run.py` now also rebuilds `.env` and force-recreates containers
 - 24/03/2026 - Migrated to Python scripts, added logging to output.log, fixed SQL data folder cleanup
 - 17/03/2026 - Improved .env management, certificate handling, and Windows compatibility

--- a/Devolutions Server/run.py
+++ b/Devolutions Server/run.py
@@ -87,6 +87,12 @@ def main() -> None:
         _install._inject_certificates(SCRIPT_DIR / ".env", CERT_DIR)
         print("✓ .env regenerated.")
 
+        # Force full SQL reconfiguration so new image/credentials are applied.
+        sentinel = SCRIPT_DIR / "data-sql" / "sql.configured"
+        if sentinel.exists():
+            sentinel.unlink()
+            print("✓ Cleared sql.configured — SQL Server will reconfigure on next start.")
+
     env = _load_env()
     if not env:
         print("⚠️  .env not found — run install.py first")


### PR DESCRIPTION
## Summary

- **run.py**: `--update` now clears the `data-sql/sql.configured` sentinel before pulling new images, ensuring SQL Server fully reconfigures when the image changes (was already in security-public, missing here)
- **.gitignore**: replaced lowercase `certificates` entry with `Certificates/*` (fixes case-sensitive Linux matching); added `data-dvls/*`, `data-sql/*`, and `tmp` which were missing

## Changed files

| File | Change |
|------|--------|
| `run.py` | Added `sql.configured` sentinel cleanup in `--update` path |
| `.gitignore` | Fixed `Certificates/*` casing; added `data-dvls/*`, `data-sql/*`, `tmp` |
| `README.md` | Added 28/04/2026 changelog entry |

## What was NOT synced

- `.env` — environment-specific credentials
- `env.template` — intentionally different passwords in this repo
- `Certificates/` — generated per-environment
- `Database/` — build-time scripts, not used in this repo (images are pre-built)
- All other files were already identical